### PR TITLE
MacOS compatibility

### DIFF
--- a/examples/clientListenerExample.cpp
+++ b/examples/clientListenerExample.cpp
@@ -141,7 +141,7 @@ int main(int argc, char **argv){
                 if(getch()=='q')
                     break;
             #endif
-            #ifdef __linux__
+            #ifdef defined(__linux__) || defined(__APPLE__)
                 if(getch()=='q')
                     break;
             #endif

--- a/examples/runDiagnostics.cpp
+++ b/examples/runDiagnostics.cpp
@@ -15,7 +15,7 @@
 #include <random>
 #include <codecvt>
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 #include <sys/stat.h>
 #include <sys/types.h>
 #endif
@@ -29,7 +29,7 @@ std::vector< std::vector<double> > random2Dmatrix(unsigned int rows, unsigned in
 // function to run the diagnostics
 int cTimings(int samples_window, int nb_channels, std::string sfield, socketStream& socketHdlr, std::ofstream& wfile); 
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
     int dirExists(std::string tpath);
 #endif
 

--- a/examples/serverExample.cpp
+++ b/examples/serverExample.cpp
@@ -85,7 +85,7 @@ int main(int argc, char **argv){
                 if(getch()=='q')
                     break;
             #endif
-            #ifdef __linux__
+            #if defined(__linux__) || defined(__APPLE__)
                 if(getch()=='q')
                     break;
             #endif

--- a/examples/serverExampleSendMsg.cpp
+++ b/examples/serverExampleSendMsg.cpp
@@ -107,7 +107,7 @@ int main(int argc, char **argv){
                 if(getch()=='q')
                     break;
             #endif
-            #ifdef __linux__
+            #ifdef defined(__linux__) || defined(__APPLE__)
                 if(getch()=='q')
                     break;
             #endif

--- a/include/socketStream.h
+++ b/include/socketStream.h
@@ -42,7 +42,9 @@
     #include <unistd.h>
     #include <stdio.h>
     #include <termios.h>
+#ifndef __APPLE__
     #include <stropts.h>
+#endif
     #include <stdio.h>
     #include <sys/select.h>
     #include <sys/ioctl.h>
@@ -265,7 +267,7 @@ public:
     
 };
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 int kbhit();
 int getch();
 #endif

--- a/socketstream_rospkg/include/socketStream.h
+++ b/socketstream_rospkg/include/socketStream.h
@@ -240,7 +240,7 @@ public:
     
 };
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 int kbhit();
 int getch();
 #endif

--- a/socketstream_rospkg/src/socketStream.cpp
+++ b/socketstream_rospkg/src/socketStream.cpp
@@ -16,7 +16,7 @@ namespace SOCKETSTREAM{
     const char *DEFAULT_HOST_IP = "localhost"; 
 }
 
-#ifdef __linux__
+#ifdef defined(__linux__) || defined(__APPLE__)
 
 
 

--- a/src/socketStream.cpp
+++ b/src/socketStream.cpp
@@ -16,7 +16,7 @@ namespace SOCKETSTREAM{
     const char *DEFAULT_HOST_IP = "localhost"; 
 }
 
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 
 
 


### PR DESCRIPTION
The `__APPLE__` in the preprocessor directives and allows for compilation.

I tested the basic functionality and seems to work normally under MacOS Catalina (10.5.5)

Side note: rapidjson also compiles without a problem